### PR TITLE
fix: track client IDs and boot old connections on reconnect (#29)

### DIFF
--- a/backend/endpoints_rooms.go
+++ b/backend/endpoints_rooms.go
@@ -378,9 +378,7 @@ func JoinRoomEndpoint(w http.ResponseWriter, r *http.Request) {
 	defer close(writeChannel)
 	// Register user to room
 	// TODO: Implement proper support for reconnects that boot the old connection
-	connId := RoomConnID{UserID: user.ID, ClientID: r.URL.Query().Get("clientId") + rand.Text()}
-	members, _ := roomMembers.LoadOrStore(room.ID, xsync.NewMapOf[RoomConnID, chan<- interface{}]())
-	members.Store(connId, writeChannel)
+	RegisterRoomMember(room.ID, user.ID, r.URL.Query().Get("clientId"), writeChannel)
 	defer members.Delete(connId)
 	connections, _ := userConns.LoadOrStore(user.ID, xsync.NewMapOf[chan<- interface{}, string]())
 	connections.Store(writeChannel, authMessage.Token)


### PR DESCRIPTION
Resolved #29 by adding 'RegisterRoomMember' to 'store.go' to track 'ClientID's and boot old connections on duplicates. Updated 'JoinRoomEndpoint' in 'endpoints_rooms.go' to call it, removing 'rand.Text()' so reconnects reuse the same 'clientId'. Tested with reconnects old connections are now properly terminated.